### PR TITLE
Add support for GHC 9.12, drop support for GHC 9.6

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -5,15 +5,16 @@ jobs:
     steps:
       - uses: actions/checkout@v4
       - run: mkdir artifact
-      - id: haskell
-        uses: haskell-actions/setup@v2
+      - uses: haskell/ghcup-setup@v1
         with:
-          ghc-version: ${{ matrix.ghc }}
+          ghc: ${{ matrix.ghc }}
+          cabal: latest
       - run: ghc-pkg list
       - run: cabal sdist --output-dir artifact
       - run: cabal configure --enable-optimization=2 --flags=pedantic --jobs
       - run: cat cabal.project.local
       - run: cp cabal.project.local artifact
+      - run: cabal update
       - run: cabal freeze
       - run: cat cabal.project.freeze
       - run: cp cabal.project.freeze artifact
@@ -21,7 +22,7 @@ jobs:
       - uses: actions/cache@v4
         with:
           key: ${{ matrix.os }}-${{ matrix.ghc }}-${{ hashFiles('cabal.project.freeze') }}
-          path: ${{ steps.haskell.outputs.cabal-store }}
+          path: ~/.local/state/cabal
           restore-keys: ${{ matrix.os }}-${{ matrix.ghc }}-
       - run: cabal build --only-download
       - run: cabal build --only-dependencies
@@ -35,17 +36,17 @@ jobs:
     strategy:
       matrix:
         include:
-          - ghc: '9.10'
+          - ghc: 9.12
             os: macos-13
-          - ghc: '9.10'
+          - ghc: 9.12
             os: macos-14
-          - ghc: 9.6
-            os: ubuntu-22.04
           - ghc: 9.8
-            os: ubuntu-22.04
+            os: ubuntu-24.04
           - ghc: '9.10'
-            os: ubuntu-22.04
-          - ghc: '9.10'
+            os: ubuntu-24.04
+          - ghc: 9.12
+            os: ubuntu-24.04
+          - ghc: 9.12
             os: windows-2022
   cabal:
     name: Cabal
@@ -85,15 +86,15 @@ jobs:
     steps:
       - uses: actions/download-artifact@v4
       - run: sh -exc 'for d in *; do cd $d; tar --extract --file artifact.tar --verbose; cd ..; done'
-      - run: cp github-release-${{ github.sha }}-ghc-9.10-ubuntu-22.04/artifact/${{ env.PREFIX }}.tar.gz .
+      - run: cp github-release-${{ github.sha }}-ghc-9.12-ubuntu-24.04/artifact/${{ env.PREFIX }}.tar.gz .
       - run: tar --auto-compress --create --file ../../${{ env.PREFIX }}-darwin-x64.tar.gz --verbose github-release
-        working-directory: github-release-${{ github.sha }}-ghc-9.10-macos-13/artifact
+        working-directory: github-release-${{ github.sha }}-ghc-9.12-macos-13/artifact
       - run: tar --auto-compress --create --file ../../${{ env.PREFIX }}-darwin-arm64.tar.gz --verbose github-release
-        working-directory: github-release-${{ github.sha }}-ghc-9.10-macos-14/artifact
+        working-directory: github-release-${{ github.sha }}-ghc-9.12-macos-14/artifact
       - run: tar --auto-compress --create --file ../../${{ env.PREFIX }}-linux-x64.tar.gz --verbose github-release
-        working-directory: github-release-${{ github.sha }}-ghc-9.10-ubuntu-22.04/artifact
+        working-directory: github-release-${{ github.sha }}-ghc-9.12-ubuntu-24.04/artifact
       - run: tar --auto-compress --create --file ../../${{ env.PREFIX }}-win32-x64.tar.gz --verbose github-release.exe
-        working-directory: github-release-${{ github.sha }}-ghc-9.10-windows-2022/artifact
+        working-directory: github-release-${{ github.sha }}-ghc-9.12-windows-2022/artifact
       - uses: softprops/action-gh-release@v2
         with:
           files: ${{ env.PREFIX }}*.tar.gz

--- a/github-release.cabal
+++ b/github-release.cabal
@@ -22,7 +22,7 @@ flag pedantic
   manual: True
 
 common library
-  build-depends: base ^>=4.18.0.0 || ^>=4.19.0.0 || ^>=4.20.0.0
+  build-depends: base ^>=4.19.0.0 || ^>=4.20.0.0 || ^>=4.21.0.0
   default-language: Haskell2010
   ghc-options:
     -Weverything


### PR DESCRIPTION
Depends on https://github.com/tfausak/burrito/pull/43. 